### PR TITLE
Fixed es6 style imports

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Ivan Verevkin <vereva@x-root.org>
 //     Updates by: Aaron Spaulding <aaron@sachimp.com>
 
-declare module 'react-datetime' {
+declare namespace reactDateTime {
 
   /*
    A stand-in type for Moment, this file currently has no way of guaranteeing
@@ -155,8 +155,12 @@ declare module 'react-datetime' {
       open: boolean;
   }
 
-  class ReactDatetime extends React.Component<DatetimepickerProps, DatetimepickerState> {
+  export class ReactDatetime extends React.Component<DatetimepickerProps, DatetimepickerState> {
   }
+}
 
+declare var ReactDatetime: typeof reactDateTime.ReactDatetime;
+
+declare module "react-datetime" {
   export = ReactDatetime;
 }


### PR DESCRIPTION
Made `import * as` syntax work in typescript

## Description
Changed the imports based on https://github.com/DefinitelyTyped/DefinitelyTyped/blob/36d40a63a05b5cb3413737fbdf7c9a2a26f211fd/react-input-calendar/react-input-calendar.d.ts

## Motivation and Context
Enables es6 imports and solves wrong hints in i.e. vscode

relates to https://github.com/YouCanBookMe/react-datetime/pull/190 ( @simeg )